### PR TITLE
Automate Prompt Hub deploy

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -24,3 +24,8 @@ jobs:
         with:
           push: true
           tags: deepset/prompthub:latest
+
+  deploy:
+    needs: push_to_registry
+    uses: ./.github/workflows/ecs-deploy.yml
+    secrets: inherit

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v[0-9].*[0-9]"
 
+env:
+  DOCKER_IMAGE_TAG: ${{ github.ref_name }}
+
 jobs:
   push_to_registry:
     name: Push Docker image to Dockerhub
@@ -23,9 +26,11 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: deepset/prompthub:latest
+          tags: deepset/prompthub:latest,deepset/prompthub:${{ env.DOCKER_IMAGE_TAG }}
 
   deploy:
     needs: push_to_registry
     uses: ./.github/workflows/ecs-deploy.yml
     secrets: inherit
+    with:
+      docker-image: deepset/prompthub:${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to Amazon ECS
+
+on:
+  workflow_call:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@0e613a0980cbf65ed5b322eb7a1e075d28913a83
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Store task definition
+        run: |
+          cat >> task-definition.json<< EOF
+          ${{ secrets.ECS_TASK_DEFINITION }}
+          EOF
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+        with:
+          task-definition: task-definition.json
+          service: ${{ secrets.ECS_SERVICE }}
+          cluster: ${{ secrets.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Calculate alert data
         id: calculator
         shell: bash
-        if: (success() || failure()) && github.ref_name == 'main'
+        if: success() || failure()
         run: |
           if [ "${{ job.status }}" = "success" ]; then
             echo "alert_type=success" >> "$GITHUB_OUTPUT";
@@ -57,14 +57,14 @@ jobs:
           fi
 
       - name: Send event to Datadog
-        if: (success() || failure()) && github.ref_name == 'main'
+        if: success() || failure()
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
           events: |
             - title: "PromptHub deployment"
-              text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
+              text: "Job ${{ github.job }} for image ${{ input.docker-image }}"
               alert_type: "${{ steps.calculator.outputs.alert_type }}"
               source_type_name: "Github"
               host: ${{ github.repository_owner }}
@@ -73,5 +73,5 @@ jobs:
                 - "job:${{ github.job }}"
                 - "run_id:${{ github.run_id }}"
                 - "workflow:${{ github.workflow }}"
-                - "branch:${{ github.ref_name }}"
+                - "image:${{ input.docker-image }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -20,9 +20,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@0e613a0980cbf65ed5b322eb7a1e075d28913a83
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Store task definition
         run: |

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -44,3 +44,34 @@ jobs:
           service: ${{ secrets.ECS_SERVICE }}
           cluster: ${{ secrets.ECS_CLUSTER }}
           wait-for-service-stability: true
+
+      - name: Calculate alert data
+        id: calculator
+        shell: bash
+        if: (success() || failure()) && github.ref_name == 'main'
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "alert_type=success" >> "$GITHUB_OUTPUT";
+          else
+            echo "alert_type=error" >> "$GITHUB_OUTPUT";
+          fi
+
+      - name: Send event to Datadog
+        if: (success() || failure()) && github.ref_name == 'main'
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "PromptHub deployment"
+              text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
+              alert_type: "${{ steps.calculator.outputs.alert_type }}"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -2,6 +2,10 @@ name: Deploy to Amazon ECS
 
 on:
   workflow_call:
+    inputs:
+      docker-image:
+        required: true
+        type: string
 
 jobs:
   deploy:
@@ -26,10 +30,18 @@ jobs:
           ${{ secrets.ECS_TASK_DEFINITION }}
           EOF
 
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@c804dfbdd57f713b6c079302a4c01db7017a36fc
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ secrets.ECS_CONTAINER_NAME }}
+          image: ${{ input.docker-image }}
+
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
         with:
-          task-definition: task-definition.json
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ secrets.ECS_SERVICE }}
           cluster: ${{ secrets.ECS_CLUSTER }}
           wait-for-service-stability: true


### PR DESCRIPTION
Add a new workflow that will deploy Prompt Hub to AWS ECS after the Docker image has been built and pushed to Docker Hub successfully.

Before merging this PR we must set the following secrets for the `ecs-deploy.yml` workflow to run correctly:
* `AWS_ROLE`
* `AWS_REGION`
* `ECS_TASK_DEFINITION`
* `ECS_SERVICE`
* `ECS_CLUSTER`
* `ECS_CONTAINER_NAME`

`ECS_TASK_DEFINITION` is meant to be the definition of the task to deploy formatted in JSON.

The `ecs-deploy.yml` has been adapted from the [Deploying to Amazon Elastic Container Service](https://docs.github.com/en/actions/deployment/deploying-to-your-cloud-provider/deploying-to-amazon-elastic-container-service) documentation.

Closes #8.