### PR TITLE
Fix API returning null fields if not set in prompt yaml

### DIFF
--- a/index/prompt.go
+++ b/index/prompt.go
@@ -3,8 +3,8 @@ package index
 // Prompt data model.
 type Prompt struct {
 	Name        string                 `json:"name"`
-	Tags        []string               `json:"tags"`
-	Meta        map[string]interface{} `json:"meta"`
+	Tags        []string               `json:"tags,omitempty"`
+	Meta        map[string]interface{} `json:"meta,omitempty"`
 	Version     string                 `json:"version"`
 	Text        string                 `json:"prompt_text" yaml:"prompt_text"`
 	Description string                 `json:"description"`


### PR DESCRIPTION
Prompt Hub currently returns `null` if a field is not set in a prompt yaml file.
That makes it harder to handle in clients, including our frontend.

Previous example response:

```
{
  "name": "deepset/language-detection",
  "tags": null,
  "meta": {
    "authors": [
      "deepset"
    ]
  },
  "version": "0.0.1",
  "prompt_text": "Detect the language in the following context and answer with the \nname of the language. \nContext: {documents}; \nAnswer:\n",
  "description": "Detech the language of the given context"
}
```

After this PR:

```
{
  "name": "deepset/language-detection",
  "meta": {
    "authors": [
      "deepset"
    ]
  },
  "version": "0.0.1",
  "prompt_text": "Detect the language in the following context and answer with the \nname of the language. \nContext: {documents}; \nAnswer:\n",
  "description": "Detech the language of the given context"
}
```