### PR TITLE
Fix docker-release and ecs-deploy workflows

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,6 +12,8 @@ jobs:
   push_to_registry:
     name: Push Docker image to Dockerhub
     runs-on: ubuntu-latest
+    outputs:
+      docker_image_tag: ${{ steps.echo.outputs.docker_image_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,9 +30,15 @@ jobs:
           push: true
           tags: deepset/prompthub:latest,deepset/prompthub:${{ env.DOCKER_IMAGE_TAG }}
 
+      - name: Output Docker image tag
+        id: echo
+        # We can't use the env context when calling another workflow
+        # so we output it here and pass it to the deploy job
+        run: echo "docker_image_tag=${{ env.DOCKER_IMAGE_TAG }}" >> "$GITHUB_OUTPUT"
+
   deploy:
     needs: push_to_registry
     uses: ./.github/workflows/ecs-deploy.yml
     secrets: inherit
     with:
-      docker-image: deepset/prompthub:${{ env.DOCKER_IMAGE_TAG }}
+      docker-image: "deepset/prompthub:${{ needs.push_to_registry.outputs.docker_image_tag }}"

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: ${{ secrets.ECS_CONTAINER_NAME }}
-          image: ${{ input.docker-image }}
+          image: ${{ inputs.docker-image }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
@@ -64,7 +64,7 @@ jobs:
           api-url: https://api.datadoghq.eu
           events: |
             - title: "PromptHub deployment"
-              text: "Job ${{ github.job }} for image ${{ input.docker-image }}"
+              text: "Job ${{ github.job }} for image ${{ inputs.docker-image }}"
               alert_type: "${{ steps.calculator.outputs.alert_type }}"
               source_type_name: "Github"
               host: ${{ github.repository_owner }}
@@ -73,5 +73,5 @@ jobs:
                 - "job:${{ github.job }}"
                 - "run_id:${{ github.run_id }}"
                 - "workflow:${{ github.workflow }}"
-                - "image:${{ input.docker-image }}"
+                - "image:${{ inputs.docker-image }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Docker release and automatic deploy are currently failing as we can't use the `env` context when calling a workflow from another one.

This PR fixes this failure:
https://github.com/deepset-ai/prompthub/actions/runs/5046628151