### PR TITLE
Fix aws configure credentials

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@0e613a0980cbf65ed5b322eb7a1e075d28913a83
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -37,14 +37,14 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@c804dfbdd57f713b6c079302a4c01db7017a36fc
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: task-definition.json
           container-name: ${{ secrets.ECS_CONTAINER_NAME }}
           image: ${{ inputs.docker-image }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ secrets.ECS_SERVICE }}

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -12,6 +12,12 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     environment: production
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    # If we remove these aws-actions/configure-aws-credentials won't assume the
+    # specified role.
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Add missing permissions necessary to use Github's OIDC Token endpoint, see [their usage instructions](https://github.com/aws-actions/configure-aws-credentials#usage).


I also updated the versions as recommended in their [README.md](https://github.com/aws-actions/configure-aws-credentials#recent-updates).

Should fix this error:
https://github.com/deepset-ai/prompthub/actions/runs/5054673313/jobs/9069892611