### PR TITLE
Change all prompts to have deepset-ai as author

### DIFF
--- a/prompts/deepset-conditioned-question-generation.yaml
+++ b/prompts/deepset-conditioned-question-generation.yaml
@@ -9,5 +9,5 @@ tags:
   - question-generation
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-conversational-agent-with-tools.yaml
+++ b/prompts/deepset-conversational-agent-with-tools.yaml
@@ -26,5 +26,5 @@ tags:
   - conversational
 meta:
   authors:
-    - deepset
+    - deepset-ai
 version: '0.1.0'

--- a/prompts/deepset-conversational-agent.yaml
+++ b/prompts/deepset-conversational-agent.yaml
@@ -7,5 +7,5 @@ tags:
   - conversational
 meta:
   authors:
-    - deepset
+    - deepset-ai
 version: '0.1.0'

--- a/prompts/deepset-conversational-summary.yaml
+++ b/prompts/deepset-conversational-summary.yaml
@@ -9,5 +9,5 @@ tags:
   - summarization
 meta:
   authors:
-    - deepset
+    - deepset-ai
 version: '0.1.0'

--- a/prompts/deepset-few-shot-hotpot-qa.yaml
+++ b/prompts/deepset-few-shot-hotpot-qa.yaml
@@ -62,5 +62,5 @@ tags:
   - agent
 meta:
   authors:
-    - deepset
+    - deepset-ai
 version: '0.1.0'

--- a/prompts/deepset-language-detection.yaml
+++ b/prompts/deepset-language-detection.yaml
@@ -9,5 +9,5 @@ tags:
   - language-detection
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-multiple-choice-question-answering.yaml
+++ b/prompts/deepset-multiple-choice-question-answering.yaml
@@ -9,5 +9,5 @@ tags:
   - question-answering
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-question-answering-check.yaml
+++ b/prompts/deepset-question-answering-check.yaml
@@ -9,5 +9,5 @@ tags:
   - question-answering
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-question-answering-per-document.yaml
+++ b/prompts/deepset-question-answering-per-document.yaml
@@ -8,5 +8,5 @@ tags:
   - question-answering
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-question-answering-with-document-scores.yaml
+++ b/prompts/deepset-question-answering-with-document-scores.yaml
@@ -16,5 +16,5 @@ tags:
   - question-answering
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-question-answering-with-references.yaml
+++ b/prompts/deepset-question-answering-with-references.yaml
@@ -12,5 +12,5 @@ tags:
 description: Provides a prompt for question answering with references to documents
 meta:
   authors:
-    - deepset
+    - deepset-ai
 version: '0.1.0'

--- a/prompts/deepset-question-answering.yaml
+++ b/prompts/deepset-question-answering.yaml
@@ -8,5 +8,5 @@ tags:
   - question-answering
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.1.1'

--- a/prompts/deepset-question-generation.yaml
+++ b/prompts/deepset-question-generation.yaml
@@ -8,5 +8,5 @@ tags:
   - question-generation
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-sentiment-analysis.yaml
+++ b/prompts/deepset-sentiment-analysis.yaml
@@ -9,5 +9,5 @@ tags:
   - sentiment-analysis
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-summarization.yaml
+++ b/prompts/deepset-summarization.yaml
@@ -7,5 +7,5 @@ tags:
   - summarization
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-topic-classification.yaml
+++ b/prompts/deepset-topic-classification.yaml
@@ -8,5 +8,5 @@ tags:
   - classification
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.0.1'

--- a/prompts/deepset-translation.yaml
+++ b/prompts/deepset-translation.yaml
@@ -6,5 +6,5 @@ tags:
   - translation
 meta: 
   authors: 
-    - deepset
+    - deepset-ai
 version: '0.1.0'

--- a/prompts/deepset-zero-shot-react.yaml
+++ b/prompts/deepset-zero-shot-react.yaml
@@ -29,5 +29,5 @@ tags:
   - agent
 meta:
   authors:
-    - deepset
+    - deepset-ai
 version: '0.1.0'


### PR DESCRIPTION
As of now all prompts have `deepset` as the author, in the fronted we use that author to link a GitHub profile.
This causes some problems since our organization is called `deepset-ai` and not `deepset`.

In this PR I change all occurences of `deepset` to `deepset-ai`.