### PR TITLE
Fix validation when validating multiple prompts

### DIFF
--- a/.github/utils/validate_prompts.py
+++ b/.github/utils/validate_prompts.py
@@ -46,8 +46,8 @@ def is_valid(prompt_file: Path) -> bool:
         for report in reports:
             print(f"  - {report}", file=sys.stderr)
 
-    # We got reports, the file must not be valid
-    return len(reports) > 0
+    # If there's any number of reports the file must not be valid
+    return len(reports) == 0
 
 
 if __name__ == "__main__":
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     files = [Path(f) for f in args.files]
 
     print()
-    any_not_valid = any([is_valid(f) for f in files])
+    any_not_valid = any([not is_valid(f) for f in files])
 
     if any_not_valid:
         sys.exit(1)

--- a/.github/workflows/prompt-validation.yml
+++ b/.github/workflows/prompt-validation.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Validate prompts
         if: steps.files.outputs.any_changed == 'true'
         run: |
-          python .github/utils/validate_prompts.py "${{ steps.files.outputs.all_changed_files }}"
+          python .github/utils/validate_prompts.py ${{ steps.files.outputs.all_changed_files }}


### PR DESCRIPTION
The `prompt-validation.yml` workflow is passing all modified prompts as a single string to the `validate_prompts.py` script. That causes it to fail as it treats it as a single file.

See example failure:
https://github.com/deepset-ai/prompthub/actions/runs/5142802893/jobs/9256991813

This PR also fixes `validate_prompts.py` failing when the file is valid.