### PR TITLE
fix: adjust links in README to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ version: v0.1
 Request:
 
 ```sh
-curl -i -H 'Accept: application/json' http://api.prompthub.deepset.ai/prompts
+curl -i -H 'Accept: application/json' https://api.prompthub.deepset.ai/prompts
 ```
 
 Response:
@@ -58,7 +58,7 @@ Content-Length: 42
 Request:
 
 ```sh
-curl -i -H 'Accept: application/json' http://api.prompthub.deepset.ai/prompts/prompt-name
+curl -i -H 'Accept: application/json' https://api.prompthub.deepset.ai/prompts/prompt-name
 ```
 
 Response:
@@ -77,7 +77,7 @@ Content-Length: 211
 Request:
 
 ```sh
-curl -i http://api.prompthub.deepset.ai/cards/prompt-name
+curl -i https://api.prompthub.deepset.ai/cards/prompt-name
 ```
 
 Response:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Content-Length: 42
         "tags":["question-answering"],
         "meta":{"authors":["Alice","Bob"]},
         "version":"1.0",
-        "prompt_text":"My prompt text",
+        "text":"My prompt text",
         "description":"Provides a prompt for question answering with references to documents"
     }
 ]
@@ -69,7 +69,7 @@ Content-Type: application/json; charset=utf-8
 Date: Fri, 24 Mar 2023 08:06:19 GMT
 Content-Length: 211
 
-{"name":"prompt-name","tags":["translation"],"meta":{"authors":["vblagoje"]},"version":"v0.1.0","prompt_text":"Your prompt text goes here","description":"Prompt to translate text into a target language"}
+{"name":"prompt-name","tags":["translation"],"meta":{"authors":["vblagoje"]},"version":"v0.1.0","text":"Your prompt text goes here","description":"Prompt to translate text into a target language"}
 ```
 
 ### Get a model card by model name


### PR DESCRIPTION
Was trying out the example curls from the README and they weren't working
```
$ curl -i -H 'Accept: application/json' http://api.prompthub.deepset.ai/prompts

curl: (7) Failed to connect to api.prompthub.deepset.ai port 80 after 214 ms: Couldn't connect to server
```

For https they are working though, so they were probably missed in an update :)