### PR TITLE
make AllowedOrigins configurable

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -21,8 +21,9 @@ func Serve() {
 	r := chi.NewRouter() // root router
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins: []string{"https://prompthub.deepset.ai"},
+		AllowedOrigins: viper.GetStringSlice("allowed_origins"),
 	}))
+	output.DEBUG.Printf("AllowedOrigins set to: %s", viper.GetStringSlice("allowed_origins"))
 
 	promptsRouter := chi.NewRouter()
 	promptsRouter.Get("/", ListPrompts)

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func initConfig(configPath *string) {
 	// Defaults
 	viper.SetDefault("port", "80")
 	viper.SetDefault("prompts_path", "./prompts")
+	viper.SetDefault("allowed_origins", []string{"https://prompthub.deepset.ai"})
 
 	// Automatically bind all the config options to env vars
 	viper.SetEnvPrefix("prompthub")
@@ -57,7 +58,9 @@ func initConfig(configPath *string) {
 	}
 	err := viper.ReadInConfig()
 	if err != nil {
-		output.FATAL.Fatalf("Fatal error: %s", err)
+		output.INFO.Println("Configuration file not found, running with default parameters")
+	} else {
+		output.DEBUG.Println("Config file found at", viper.ConfigFileUsed())
 	}
-	output.DEBUG.Println("Config file found at", viper.ConfigFileUsed())
+
 }

--- a/prompthub.yaml.example
+++ b/prompthub.yaml.example
@@ -1,2 +1,4 @@
 port: 80
 prompts_path: ./prompts
+allowed_origins:
+    - http://localhost:5173


### PR DESCRIPTION
The `AllowedOrigins` header can be customisable by either of:
- launch the process with the `PROMPTHUB_ALLOWED_ORIGINS` env var set, e.g. `PROMPTHUB_ALLOWED_ORIGINS=http://localhost:5173 ./prompthub `
- add a `allowed_origins` array to the config file (see `prompthub.yaml.example`)