### PR TITLE
run the service with default values in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN go build
 FROM alpine:3.17
 
 COPY --from=build /go/src/github.com/deepset-ai/prompthub/prompthub /usr/bin/prompthub
-COPY prompthub.yaml.example /prompthub.yaml
+# In case you don't want to run the service wit default values,
+# put your configuration in the example file and uncomment the
+# following line:
+# COPY prompthub.yaml.example /prompthub.yaml
 COPY prompts ./prompts
 EXPOSE 80
 CMD ["prompthub", "-c /prompthub.yaml"]


### PR DESCRIPTION
We were using the example config file in the official docker image, which is not great - in fact we broke the service in production.

I think by running the service with its defaults in the docker image we cause the least amount of surprises.